### PR TITLE
Changes to close the input stream on the yaml.load exception, fixes #3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.mcmanus.scm.stash</groupId>
     <artifactId>yaml-validator-hook</artifactId>
-    <version>2.0.2-SNAPSHOT</version>
+    <version>2.1.0-SNAPSHOT</version>
     <organization>
         <name>Hugh McManus</name>
         <url>https://github.com/hmcmanus/yaml-validator-hook</url>
@@ -139,8 +139,8 @@
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
                 <version>3.3</version>
             </plugin>

--- a/src/main/java/com/mcmanus/scm/stash/hook/YamlFileValidator.java
+++ b/src/main/java/com/mcmanus/scm/stash/hook/YamlFileValidator.java
@@ -32,7 +32,9 @@ public class YamlFileValidator {
                 LOG.info("Attempting to validate file: " + filePath);
                 yaml.load(input);
             } catch (Exception e) {
-                LOG.info("Rejecting push because following yaml file is invalid " + filePath);
+                LOG.debug("Closing the input stream after exception with yaml load");
+                input.close();
+                LOG.info("Rejecting push because following yaml file is invalid: " + filePath);
                 hookResponse.err().println("ERROR: Invalid yaml file: " + filePath);
                 hookResponse.err().println(e.getMessage());
                 fileIsValid = false;
@@ -42,10 +44,13 @@ public class YamlFileValidator {
         } finally {
             if (input != null) {
                 try {
+                    LOG.debug("Attempting to close the input stream");
                     input.close();
                 } catch (IOException e) {
                     LOG.error("Unable to close input stream");
                 }
+            } else {
+                LOG.debug("input stream found to be null");
             }
         }
         return fileIsValid;

--- a/src/main/java/com/mcmanus/scm/stash/hook/YamlValidatorPreReceiveRepositoryHook.java
+++ b/src/main/java/com/mcmanus/scm/stash/hook/YamlValidatorPreReceiveRepositoryHook.java
@@ -135,6 +135,7 @@ public class YamlValidatorPreReceiveRepositoryHook implements PreReceiveReposito
                     LOG.debug("Writing temporary yaml file in order to validate " + tempFilePath);
                     outputStream.writeTo(Files.newOutputStream(tempFilePath));
                 } finally {
+                    LOG.debug("Attempting to close the output stream");
                     outputStream.close();
                 }
 


### PR DESCRIPTION
This pull request fixes the problem with the plugin where it kept open file handles open when the yaml load had an exception. It seems the outer finnally wasn't being called and therefore the input.close() was never being called. 
