### PR TITLE
Add ability to provide yaml file extension value

### DIFF
--- a/src/main/resources/atlassian-plugin.xml
+++ b/src/main/resources/atlassian-plugin.xml
@@ -33,6 +33,10 @@
         <description key="yaml-validator-hook.description">Rejects invalid yaml files pushed to the repository
         </description>
         <icon>images/GoodBad.jpeg</icon>
+        <config-form name="External Async Post Receive Hook Config" key="external-post-receive-hook-config">
+            <view>com.mcmanus.scm.stash.hook.yamlvalidatorprereceivehook.view</view>
+            <directory location="/static/"/>
+        </config-form>
     </repository-hook>
 
 </atlassian-plugin>

--- a/src/main/resources/static/yaml-validator-pre-receive-hook.soy
+++ b/src/main/resources/static/yaml-validator-pre-receive-hook.soy
@@ -1,0 +1,21 @@
+{namespace com.mcmanus.scm.stash.hook.yamlvalidatorprereceivehook}
+
+/**
+ * @param? config
+ * @param? errors
+ */
+{template .view}
+    {call aui.form.textField}
+        {param id: 'extension' /}
+        {param value: $config['extension'] ? 'yaml' : 'yaml' /}
+        {param labelContent: 'Yaml file extension:' /}
+        {param descriptionText: 'Yaml file extension can be single value (e.g. yaml) or regexp (e.g. ya?ml).' /}
+        {param errorTexts: $errors ? $errors['extension'] : null /}
+    {/call}
+
+    <div class="field-group">
+        <div class="description">
+        Learn more about this field at the <a href="https://github.com/hmcmanus/yaml-validator-hook/wiki" target="_blank">official wiki page</a>.
+        </div>
+    </div>
+{/template}


### PR DESCRIPTION
This can be useful when you are dealing with yaml files with extensions like:
- yml
- sls

For example I could use:

```
(?i)ya?ml|sls
```
