### PR TITLE
Fix Regex Display Bug

### DIFF
--- a/src/main/resources/static/yaml-validator-pre-receive-hook.soy
+++ b/src/main/resources/static/yaml-validator-pre-receive-hook.soy
@@ -7,7 +7,7 @@
 {template .view}
     {call aui.form.textField}
         {param id: 'extension' /}
-        {param value: $config['extension'] ? 'yaml' : 'yaml' /}
+        {param value: $config['extension'] ? $config['extension'] : 'yaml' /}
         {param labelContent: 'Yaml file extension:' /}
         {param descriptionText: 'Yaml file extension can be single value (e.g. yaml) or regexp (e.g. ya?ml).' /}
         {param errorTexts: $errors ? $errors['extension'] : null /}


### PR DESCRIPTION
Fix display bug where the value 'yaml' would always be shown, even if the regex had been changed to something else.