### PR TITLE
add scope for repository and project

### DIFF
--- a/src/main/resources/atlassian-plugin.xml
+++ b/src/main/resources/atlassian-plugin.xml
@@ -32,6 +32,10 @@
             <view>com.mcmanus.scm.stash.hook.yamlvalidatorprereceivehook.view</view>
             <directory location="/static/"/>
         </config-form>
+         <scopes>
+            <scope>project</scope>
+            <scope>repository</scope>
+        </scopes>
     </repository-hook>
 
 </atlassian-plugin>


### PR DESCRIPTION
Allow the ability to set up the plugin at the project level rather than for each repository. The good thing here is you can override the configuration at each repository level afterwards.