### PR TITLE
Accept value tags when validating YAML

### DIFF
--- a/src/main/java/com/mcmanus/scm/stash/hook/YamlValidatorConstructor.java
+++ b/src/main/java/com/mcmanus/scm/stash/hook/YamlValidatorConstructor.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2008, SnakeYAML
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.mcmanus.scm.stash.hook;
+
+import org.yaml.snakeyaml.LoaderOptions;
+import org.yaml.snakeyaml.constructor.AbstractConstruct;
+import org.yaml.snakeyaml.constructor.Construct;
+import org.yaml.snakeyaml.constructor.Constructor;
+import org.yaml.snakeyaml.error.YAMLException;
+import org.yaml.snakeyaml.nodes.Node;
+import org.yaml.snakeyaml.nodes.Tag;
+
+/**
+ * A SnakeYAML Constructor which ignores and value tags.
+ *
+ * Slightly adapted version of SnakeYAML's examples.IgnoreTagsExampleTest.MyConstructor.
+ */
+public class YamlValidatorConstructor extends Constructor {
+
+    public YamlValidatorConstructor(LoaderOptions loadingConfig) {
+        super(loadingConfig);
+
+        this.yamlConstructors.put(null, new IgnoringConstruct());
+    }
+
+    private class IgnoringConstruct extends AbstractConstruct {
+
+        @Override
+        public Object construct(Node node) {
+            switch (node.getNodeId()) {
+                case scalar:
+                    return yamlConstructors.get(Tag.STR).construct(node);
+                case sequence:
+                    return yamlConstructors.get(Tag.SEQ).construct(node);
+                case mapping:
+                    return yamlConstructors.get(Tag.MAP).construct(node);
+                default:
+                    throw new YAMLException("Unexpected node");
+            }
+        }
+
+    }
+}

--- a/src/main/java/com/mcmanus/scm/stash/hook/YamlValidatorPreReceiveRepositoryHook.java
+++ b/src/main/java/com/mcmanus/scm/stash/hook/YamlValidatorPreReceiveRepositoryHook.java
@@ -177,7 +177,7 @@ public class YamlValidatorPreReceiveRepositoryHook implements PreRepositoryHook
         boolean validFile = true;
         LoaderOptions loaderOptions = new LoaderOptions();
         loaderOptions.setAllowDuplicateKeys(true);
-        Yaml yaml = new Yaml(loaderOptions);
+        Yaml yaml = new Yaml(new YamlValidatorConstructor(loaderOptions));
         try {
             LOG.info("Attempting to validate yaml stream");
             int documentCount = 1;

--- a/src/test/java/com/mcmanus/scm/stash/hook/YamlValidatorPreReceiveRepositoryHookTest.java
+++ b/src/test/java/com/mcmanus/scm/stash/hook/YamlValidatorPreReceiveRepositoryHookTest.java
@@ -8,6 +8,7 @@ import com.atlassian.bitbucket.repository.Repository;
 import com.atlassian.bitbucket.util.Page;
 import com.atlassian.bitbucket.util.PageRequest;
 import com.atlassian.bitbucket.util.PageUtils;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.springframework.core.io.ClassPathResource;
 
@@ -147,5 +148,25 @@ public class YamlValidatorPreReceiveRepositoryHookTest {
         boolean check = hook.checkFile(testString, results, resource.getPath());
 
         assertFalse(check);
+    }
+
+    @Ignore("https://github.com/hmcmanus/yaml-validator-hook/issues/25")
+    @Test
+    public void shouldTestTaggedYamlFile() throws IOException {
+        CommitService commitServiceMock = mock(CommitService.class);
+        ContentService contentServiceMock = mock(ContentService.class);
+        CommitIndex commitIndexMock = mock(CommitIndex.class);
+
+        ClassPathResource classPathResource = new ClassPathResource("tagged.yaml");
+        File resource = classPathResource.getFile();
+        String testString = new String(Files.readAllBytes(Paths.get(resource.getPath())));
+
+        YamlValidatorPreReceiveRepositoryHook hook = new YamlValidatorPreReceiveRepositoryHook(commitServiceMock,
+                contentServiceMock, commitIndexMock);
+
+        ConcurrentMap<String, String> results = new ConcurrentHashMap<>();
+        boolean check = hook.checkFile(testString, results, resource.getPath());
+
+        assertTrue(check);
     }
 }

--- a/src/test/java/com/mcmanus/scm/stash/hook/YamlValidatorPreReceiveRepositoryHookTest.java
+++ b/src/test/java/com/mcmanus/scm/stash/hook/YamlValidatorPreReceiveRepositoryHookTest.java
@@ -150,7 +150,6 @@ public class YamlValidatorPreReceiveRepositoryHookTest {
         assertFalse(check);
     }
 
-    @Ignore("https://github.com/hmcmanus/yaml-validator-hook/issues/25")
     @Test
     public void shouldTestTaggedYamlFile() throws IOException {
         CommitService commitServiceMock = mock(CommitService.class);

--- a/src/test/resources/tagged.yaml
+++ b/src/test/resources/tagged.yaml
@@ -1,0 +1,8 @@
+foo: !foo 42
+bar: !bar |
+  multi
+  line
+baz: !baz
+  - a
+  - b
+  - c


### PR DESCRIPTION
This fixes #25. After this change the validator will accept any `!tag`s  on values.

I took the code from upstream's [IgnoreTagsExampleTest.java](https://bitbucket.org/snakeyaml/snakeyaml/src/snakeyaml-1.33/src/test/java/examples/IgnoreTagsExampleTest.java) and amended it slightly. I put it into a separate file since it made keeping to copyright notice simpler.

I can move it to an inner class or change the name if preferred.