### PR TITLE
Adding a bad tagged yaml file to check if tags are validated

### DIFF
--- a/src/test/java/com/mcmanus/scm/stash/hook/YamlValidatorPreReceiveRepositoryHookTest.java
+++ b/src/test/java/com/mcmanus/scm/stash/hook/YamlValidatorPreReceiveRepositoryHookTest.java
@@ -168,4 +168,23 @@ public class YamlValidatorPreReceiveRepositoryHookTest {
 
         assertTrue(check);
     }
+
+    @Test
+    public void shouldTestMalformedTaggedYamlFile() throws IOException {
+        CommitService commitServiceMock = mock(CommitService.class);
+        ContentService contentServiceMock = mock(ContentService.class);
+        CommitIndex commitIndexMock = mock(CommitIndex.class);
+
+        ClassPathResource classPathResource = new ClassPathResource("tagged-bad.yaml");
+        File resource = classPathResource.getFile();
+        String testString = new String(Files.readAllBytes(Paths.get(resource.getPath())));
+
+        YamlValidatorPreReceiveRepositoryHook hook = new YamlValidatorPreReceiveRepositoryHook(commitServiceMock,
+                contentServiceMock, commitIndexMock);
+
+        ConcurrentMap<String, String> results = new ConcurrentHashMap<>();
+        boolean check = hook.checkFile(testString, results, resource.getPath());
+
+        assertFalse(check);
+    }
 }

--- a/src/test/resources/tagged-bad.yaml
+++ b/src/test/resources/tagged-bad.yaml
@@ -1,0 +1,8 @@
+foo: !foo '42
+bar: !bar |
+  multi
+  line
+baz: !baz
+  - a
+  - b
+  - c


### PR DESCRIPTION
In addition to the pull request submitted to deal with tagged yaml this pull request adds a malformed tagged yaml file to test that the plugin will reject tagged yaml that is also malformed. 